### PR TITLE
the double slashes color made optional

### DIFF
--- a/sass/oscailte/base/_global.scss
+++ b/sass/oscailte/base/_global.scss
@@ -25,7 +25,7 @@ a {
     }
     &::before {
         content: "// ";
-        color: $color--primary;
+        color: $double--slash-color;
     }
 }
 


### PR DESCRIPTION
I added a variable in _variables.scss for the "//" in the // POST VARIABLES section. By default it will grab the $post--title-color but now it is optional for more freedom.
